### PR TITLE
Rough draft of field authorization.

### DIFF
--- a/src/Types/CreateInputType.php
+++ b/src/Types/CreateInputType.php
@@ -52,7 +52,11 @@ class CreateInputType extends InputType
     private function getFillableFields(): array
     {
         return array_filter($this->model->fields(), function ($value, $key) {
-            $type = Type::getNamedType($value);
+            if (is_array($value)) {
+                $type = Type::getNamedType($value['type']);
+            } else {
+                $type = Type::getNamedType($value);
+            }
             $fillable = array_values($this->model->getFillable());
 
             return in_array($key, $fillable) && Type::isLeafType($type);

--- a/src/Types/EntityType.php
+++ b/src/Types/EntityType.php
@@ -20,10 +20,7 @@ class EntityType extends Type
 
     public function fields(): array
     {
-        $fields = array_merge(
-            $this->model->fields(),
-            $this->model->relations()
-        );
+        $fields = $this->model->relations();
 
         foreach ($this->model->relations() as $key => $type) {
             if ($type instanceof ListOfType) {
@@ -43,6 +40,25 @@ class EntityType extends Type
                         return $instance ? $instance->getKey() : null;
                     }
                 ];
+            }
+        }
+
+        foreach ($this->model->fields() as $key => $field) {
+            if (!is_array($field)) {
+                $fields[$key] = $field;
+            } else {
+                if (array_key_exists('readable', $field)) {
+                    $fields[$key] = [
+                        'type' => $field['type'],
+                        'resolve' => function ($source, $args, $viewer) use ($key, $field) {
+                            return $field['readable']($source, $args, $viewer)
+                                ? $source->getAttribute($key)
+                                : null;
+                        }
+                    ];
+                } else {
+                    $fields[$key] = $field;
+                }
             }
         }
 

--- a/src/Types/UpdateInputType.php
+++ b/src/Types/UpdateInputType.php
@@ -2,9 +2,9 @@
 
 namespace Bakery\Types;
 
-use GraphQL\Type\Definition\Type;
 use Bakery\Support\Facades\Bakery;
 use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations;
 
@@ -53,7 +53,11 @@ class UpdateInputType extends InputType
     private function getFillableFields(): array
     {
         $fields = array_filter($this->model->fields(), function ($value, $key) {
-            $type = Type::getNamedType($value);
+            if (is_array($value)) {
+                $type = Type::getNamedType($value['type']);
+            } else {
+                $type = Type::getNamedType($value);
+            }
             $fillable = array_values($this->model->getFillable());
 
             return in_array($key, $fillable) && Type::isLeafType($type);

--- a/tests/Stubs/Policies/UserPolicy.php
+++ b/tests/Stubs/Policies/UserPolicy.php
@@ -3,6 +3,7 @@
 namespace Bakery\Tests\Stubs\Policies;
 
 use Bakery\Tests\Stubs\User;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class UserPolicy
 {
@@ -57,5 +58,10 @@ class UserPolicy
     public function createPosts(User $user): bool
     {
         return true;
+    }
+
+    public function readPassword(Authenticatable $viewer, User $user): bool
+    {
+        return $user->is($viewer);
     }
 }

--- a/tests/Stubs/Policies/UserPolicy.php
+++ b/tests/Stubs/Policies/UserPolicy.php
@@ -62,6 +62,6 @@ class UserPolicy
 
     public function readPassword(Authenticatable $viewer, User $user): bool
     {
-        return $user->is($viewer);
+        return $viewer && $user->is($viewer);
     }
 }

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -47,6 +47,12 @@ class User extends Authenticatable
             'name' => Type::string(),
             'email' => Type::string(),
             'password' => Type::string(),
+            'secret_information' => [
+                'type' => Type::string(),
+                'readable' => function ($user, $args, $viewer) {
+                    return $user->is($viewer);
+                }
+            ]
         ];
     }
 

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -53,7 +53,7 @@ class User extends Authenticatable
             'secret_information' => [
                 'type' => Type::string(),
                 'readable' => function ($user, $args, $viewer) {
-                    return $user->is($viewer);
+                    return $viewer && $user->is($viewer);
                 }
             ]
         ];

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -18,7 +18,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $attributes = [
-        'password' => 'secret'
+        'password' => 'secret',
     ];
 
     /**
@@ -46,7 +46,10 @@ class User extends Authenticatable
             'id' => Type::ID(),
             'name' => Type::string(),
             'email' => Type::string(),
-            'password' => Type::string(),
+            'password' => [
+                'type' => Type::string(),
+                'policy' => 'readPassword',
+            ],
             'secret_information' => [
                 'type' => Type::string(),
                 'readable' => function ($user, $args, $viewer) {

--- a/tests/WithDatabase.php
+++ b/tests/WithDatabase.php
@@ -36,6 +36,7 @@ trait WithDatabase
             $table->string('email');
             $table->string('name');
             $table->string('password');
+            $table->string('secret_information')->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
Thinking about the following API

Use a closure

```php
$fields = [
    'secret' => [
        'type' => Bakery::string(),
        'readable' => function ($source, $args, $viewer) { return true; }
    ]
]
```

Or a policy

```php
$fields = [
    'secret' => [
        'type' => Bakery::string(),
        'policy' => 'readSecret',
    ]
]
```

This will call `$viewer->can($policy)`;

What do you think @erikgaal ?