### PR TITLE
🚔 Store policies

### DIFF
--- a/src/Contracts/Introspectable.php
+++ b/src/Contracts/Introspectable.php
@@ -29,7 +29,7 @@ interface Introspectable
 
     public function getConnections(): Collection;
 
-    public function getBakeryQuery(?Authenticatable $viewer): Builder;
+    public function getBakeryQuery(): Builder;
 
     public function scopeQuery(Builder $builder): Builder;
 }

--- a/src/Eloquent/Concerns/InteractsWithAttributes.php
+++ b/src/Eloquent/Concerns/InteractsWithAttributes.php
@@ -2,8 +2,6 @@
 
 namespace Bakery\Eloquent\Concerns;
 
-use GraphQL\Error\UserError;
-
 trait InteractsWithAttributes
 {
     /**
@@ -14,13 +12,7 @@ trait InteractsWithAttributes
     protected function fillScalars(array $scalars)
     {
         foreach ($scalars as $key => $value) {
-            try {
-                $this->fillScalar($key, $value);
-            } catch (\Exception $previous) {
-                throw new UserError('Could not set '.$key, [
-                    $key => $previous->getMessage(),
-                ]);
-            }
+            $this->fillScalar($key, $value);
         }
     }
 
@@ -33,11 +25,8 @@ trait InteractsWithAttributes
      */
     protected function fillScalar(string $key, $value)
     {
-        $policyMethod = 'set'.studly_case($key).'Attribute';
-
-        if (method_exists($this->policy(), $policyMethod)) {
-            $this->gate->authorize($policyMethod, [$this, $value]);
-        }
+        $field = $this->getSchema()->getFields()->get($key);
+        $field->checkStorePolicy($this->getModel(), $key);
 
         return $this->setAttribute($key, $value);
     }

--- a/src/Eloquent/Concerns/InteractsWithQueries.php
+++ b/src/Eloquent/Concerns/InteractsWithQueries.php
@@ -10,16 +10,15 @@ trait InteractsWithQueries
     /**
      * Boot the query builder on the underlying model.
      *
-     * @param \Illuminate\Contracts\Auth\Authenticatable|null $viewer
      * @return Builder
      */
-    public function getBakeryQuery(?Authenticatable $viewer): Builder
+    public function getBakeryQuery(): Builder
     {
         $model = $this->getModel();
         $query = $model->query();
 
         if (method_exists($model, 'scopeAuthorizedForReading')) {
-            $query = $query->authorizedForReading($viewer);
+            $query = $query->authorizedForReading(auth()->user());
         }
 
         return $this->scopeQuery($query);

--- a/src/Mutations/AttachPivotMutation.php
+++ b/src/Mutations/AttachPivotMutation.php
@@ -83,13 +83,13 @@ class AttachPivotMutation extends EntityMutation
      *
      * @param  mixed $root
      * @param  array $args
-     * @param  mixed $viewer
+     * @param  mixed $context
      * @return Model
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function resolve($root, array $args, $viewer): Model
+    public function resolve($root, array $args, $context): Model
     {
-        $model = $this->findOrFail($root, $args, $viewer);
+        $model = $this->findOrFail($root, $args, $context);
         $relation = $model->{$this->pivotRelation->getRelationName()}();
 
         $permission = 'set'.studly_case($relation->getRelationName());

--- a/src/Mutations/Concerns/QueriesModel.php
+++ b/src/Mutations/Concerns/QueriesModel.php
@@ -13,14 +13,14 @@ trait QueriesModel
      *
      * @param mixed $root
      * @param array $args
-     * @param mixed $viewer
+     * @param mixed $context
      * @return mixed
      */
-    public function find($root, array $args, $viewer)
+    public function find($root, array $args, $context)
     {
         $primaryKey = $this->model->getKeyName();
 
-        $query = $this->schema->getBakeryQuery($viewer);
+        $query = $this->schema->getBakeryQuery();
 
         if (array_key_exists($primaryKey, $args)) {
             return $query->find($args[$primaryKey]);
@@ -47,12 +47,12 @@ trait QueriesModel
      *
      * @param mixed $root
      * @param array $args
-     * @param mixed $viewer
+     * @param mixed $context
      * @return Model
      */
-    public function findOrFail($root, array $args, $viewer): Model
+    public function findOrFail($root, array $args, $context): Model
     {
-        $result = $this->find($root, $args, $viewer);
+        $result = $this->find($root, $args, $context);
 
         if (! $result) {
             throw (new ModelNotFoundException)->setModel(class_basename($this->model));

--- a/src/Mutations/CreateMutation.php
+++ b/src/Mutations/CreateMutation.php
@@ -25,11 +25,11 @@ class CreateMutation extends EntityMutation
      *
      * @param  mixed $root
      * @param  array $args
-     * @param  mixed $viewer
+     * @param  mixed $context
      * @return Model
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function resolve($root, array $args, $viewer): Model
+    public function resolve($root, array $args, $context): Model
     {
         $this->authorize('create', $this->model);
 

--- a/src/Mutations/DeleteMutation.php
+++ b/src/Mutations/DeleteMutation.php
@@ -47,14 +47,14 @@ class DeleteMutation extends EntityMutation
      *
      * @param  mixed $root
      * @param  array $args
-     * @param  mixed $viewer
+     * @param  mixed $context
      * @return Model
      * @throws \Illuminate\Auth\Access\AuthorizationException
      * @throws \Exception
      */
-    public function resolve($root, array $args, $viewer): Model
+    public function resolve($root, array $args, $context): Model
     {
-        $model = $this->findOrFail($root, $args, $viewer);
+        $model = $this->findOrFail($root, $args, $context);
         $this->authorize('delete', $model);
 
         $model->delete();

--- a/src/Mutations/DetachPivotMutation.php
+++ b/src/Mutations/DetachPivotMutation.php
@@ -75,13 +75,13 @@ class DetachPivotMutation extends EntityMutation
      *
      * @param  mixed $root
      * @param  array $args
-     * @param  mixed $viewer
+     * @param  mixed $context
      * @return Model
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function resolve($root, array $args, $viewer): Model
+    public function resolve($root, array $args, $context): Model
     {
-        $model = $this->findOrFail($root, $args, $viewer);
+        $model = $this->findOrFail($root, $args, $context);
         $relation = $model->{$this->pivotRelation->getRelationName()}();
 
         $permission = 'set'.studly_case($relation->getRelationName());

--- a/src/Mutations/EntityMutation.php
+++ b/src/Mutations/EntityMutation.php
@@ -56,8 +56,8 @@ abstract class EntityMutation extends Mutation
      *
      * @param mixed $root
      * @param mixed $args
-     * @param mixed $viewer
+     * @param mixed $context
      * @return Model
      */
-    abstract public function resolve($root, array $args, $viewer): Model;
+    abstract public function resolve($root, array $args, $context): Model;
 }

--- a/src/Mutations/UpdateMutation.php
+++ b/src/Mutations/UpdateMutation.php
@@ -38,13 +38,13 @@ class UpdateMutation extends EntityMutation
      *
      * @param  mixed $root
      * @param  array $args
-     * @param  mixed $viewer
+     * @param  mixed $context
      * @return Model
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function resolve($root, array $args, $viewer): Model
+    public function resolve($root, array $args, $context): Model
     {
-        $model = $this->findOrFail($root, $args, $viewer);
+        $model = $this->findOrFail($root, $args, $context);
         $this->authorize('update', $model);
 
         $input = $args['input'];

--- a/src/Queries/EntityCollectionQuery.php
+++ b/src/Queries/EntityCollectionQuery.php
@@ -71,11 +71,11 @@ class EntityCollectionQuery extends EntityQuery
      *
      * @param mixed $root
      * @param array $args
-     * @param mixed $viewer
+     * @param mixed $context
      * @return LengthAwarePaginator
      * @throws PaginationMaxCountExceededException
      */
-    public function resolve($root, array $args, $viewer)
+    public function resolve($root, array $args, $context)
     {
         $page = array_get($args, 'page', 1);
         $count = array_get($args, 'count', 15);
@@ -87,9 +87,9 @@ class EntityCollectionQuery extends EntityQuery
         }
 
         $query = $this->scopeQuery(
-            $this->schema->getBakeryQuery($viewer),
+            $this->schema->getBakeryQuery($context),
             $args,
-            $viewer
+            $context
         );
 
         if (array_key_exists('filter', $args) && ! empty($args['filter'])) {

--- a/src/Queries/EntityQuery.php
+++ b/src/Queries/EntityQuery.php
@@ -16,11 +16,9 @@ abstract class EntityQuery extends Query
      * This can be overwritten to make your own collection queries.
      *
      * @param Builder $query
-     * @param array $args
-     * @param $viewer
      * @return Builder
      */
-    protected function scopeQuery(Builder $query, array $args, $viewer): Builder
+    protected function scopeQuery(Builder $query): Builder
     {
         return $query;
     }

--- a/src/Queries/SingleEntityQuery.php
+++ b/src/Queries/SingleEntityQuery.php
@@ -50,18 +50,14 @@ class SingleEntityQuery extends EntityQuery
      *
      * @param mixed $root
      * @param array $args
-     * @param mixed $viewer
+     * @param mixed $context
      * @return Model
      */
-    public function resolve($root, array $args, $viewer)
+    public function resolve($root, array $args, $context)
     {
         $primaryKey = $this->model->getKeyName();
 
-        $query = $this->scopeQuery(
-            $this->schema->getBakeryQuery($viewer),
-            $args,
-            $viewer
-        );
+        $query = $this->scopeQuery($this->schema->getBakeryQuery());
 
         if (array_key_exists($primaryKey, $args)) {
             return $query->find($args[$primaryKey]);

--- a/src/Types/Definitions/Type.php
+++ b/src/Types/Definitions/Type.php
@@ -258,11 +258,11 @@ class Type
     /**
      * Set the store policy with a callable.
      *
-     * @param callable $callable
+     * @param \Closure $closure
      * @return \Bakery\Types\Definitions\Type
      */
-    public function canStore(callable $callable) {
-        $this->storePolicy($callable);
+    public function canStore(\Closure $closure) {
+        $this->storePolicy($closure);
 
         return $this;
     }

--- a/src/Types/Definitions/Type.php
+++ b/src/Types/Definitions/Type.php
@@ -263,9 +263,7 @@ class Type
      */
     public function canStore(\Closure $closure)
     {
-        $this->storePolicy($closure);
-
-        return $this;
+        return $this->storePolicy($closure);
     }
 
     /**
@@ -276,9 +274,7 @@ class Type
      */
     public function canStoreWhen(string $policy)
     {
-        $this->storePolicy = $policy;
-
-        return $this;
+        return $this->storePolicy($policy);
     }
 
     /**

--- a/src/Types/Definitions/Type.php
+++ b/src/Types/Definitions/Type.php
@@ -284,13 +284,15 @@ class Type
      *
      * @param $source
      * @param $fieldName
-     * @return void
+     * @return bool
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function checkStorePolicy($source, $fieldName)
     {
         $user = auth()->user();
         $policy = $this->storePolicy;
+
+        /** @var Gate $gate */
         $gate = app(Gate::class)->forUser($user);
 
         // Check if the policy method is a closure.
@@ -299,9 +301,11 @@ class Type
         }
 
         // Check if there is a policy with this name
-        if (is_string($policy) && ! $gate->check($policy, $source)) {
+        if (is_string($policy) && ! $gate->check($policy, [$source])) {
             throw new AuthorizationException('Cannot set property "'.$fieldName.'" of '.get_class($source));
         }
+
+        return true;
     }
 
     /**

--- a/src/Types/Definitions/Type.php
+++ b/src/Types/Definitions/Type.php
@@ -68,6 +68,13 @@ class Type
     protected $policy;
 
     /**
+     * The policy for storing the value of the type.
+     *
+     * @var callable|string
+     */
+    protected $storePolicy;
+
+    /**
      * Construct a new type.
      *
      * @param null $type
@@ -181,16 +188,16 @@ class Type
      */
     protected function getResolver()
     {
-        return function ($source, $args, $viewer, ResolveInfo $info) {
+        return function ($source, array $args, $context, ResolveInfo $info) {
             if (isset($this->policy)) {
-                $this->checkPolicy($source, $args, $viewer, $info);
+                $this->checkPolicy($source, $args, $context, $info);
             }
 
             if (isset($this->resolver)) {
-                return call_user_func_array($this->resolver, [$source, $args, $viewer]);
+                return call_user_func_array($this->resolver, [$source, $args, $context, $info]);
             }
 
-            return self::defaultResolver($source, $args, $viewer, $info);
+            return self::defaultResolver($source, $args, $context, $info);
         };
     }
 
@@ -212,25 +219,88 @@ class Type
      *
      * @param $source
      * @param $args
-     * @param $viewer
+     * @param $context
      * @param ResolveInfo $info
      * @return void
      * @throws AuthorizationException
      */
-    protected function checkPolicy($source, $args, $viewer, ResolveInfo $info)
+    protected function checkPolicy($source, $args, $context, ResolveInfo $info)
     {
+        $user = auth()->user();
         $policy = $this->policy;
-        $gate = app(Gate::class)->forUser($viewer);
+        $gate = app(Gate::class)->forUser($user);
         $fieldName = $info->fieldName;
 
         // Check if the policy method is callable
-        if (is_callable($policy) && ! $policy($source, $args, $viewer, $info)) {
+        if (is_callable($policy) && ! $policy($user, $source, $args, $context, $info)) {
             throw new AuthorizationException('Cannot read property "'.$fieldName.'" of '.get_class($source));
         }
 
         // Check if there is a policy with this name
         if (is_string($policy) && ! $gate->check($policy, $source)) {
             throw new AuthorizationException('Cannot read property "'.$fieldName.'" of '.get_class($source));
+        }
+    }
+
+    /**
+     * Set the story policy.
+     *
+     * @param $policy
+     * @return \Bakery\Types\Definitions\Type
+     */
+    public function storePolicy($policy)
+    {
+        $this->storePolicy = $policy;
+
+        return $this;
+    }
+
+    /**
+     * Set the store policy with a callable.
+     *
+     * @param callable $callable
+     * @return \Bakery\Types\Definitions\Type
+     */
+    public function canStore(callable $callable) {
+        $this->storePolicy($callable);
+
+        return $this;
+    }
+
+    /**
+     * Set the store policy with a reference to a policy method.
+     *
+     * @param string $policy
+     * @return \Bakery\Types\Definitions\Type
+     */
+    public function canStoreWhen(string $policy) {
+        $this->storePolicy = $policy;
+
+        return $this;
+    }
+
+    /**
+     * Check the store policy of the type.
+     *
+     * @param $source
+     * @param $fieldName
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function checkStorePolicy($source, $fieldName)
+    {
+        $user = auth()->user();
+        $policy = $this->storePolicy;
+        $gate = app(Gate::class)->forUser($user);
+
+        // Check if the policy method is a closure.
+        if ($policy instanceof \Closure && ! $policy($source)) {
+            throw new AuthorizationException('Cannot set property "'.$fieldName.'" of '.get_class($source));
+        }
+
+        // Check if there is a policy with this name
+        if (is_string($policy) && ! $gate->check($policy, $source)) {
+            throw new AuthorizationException('Cannot set property "'.$fieldName.'" of '.get_class($source));
         }
     }
 
@@ -358,12 +428,12 @@ class Type
      * This gets called when there is no custom resolver defined.
      *
      * @param $source
-     * @param $args
-     * @param $viewer
+     * @param array $args
+     * @param $context
      * @param \GraphQL\Type\Definition\ResolveInfo $info
      * @return mixed|null
      */
-    protected static function defaultResolver($source, $args, $viewer, ResolveInfo $info)
+    protected static function defaultResolver($source, array $args, $context, ResolveInfo $info)
     {
         $fieldName = $info->fieldName;
         $property = null;
@@ -378,6 +448,6 @@ class Type
             }
         }
 
-        return $property instanceof \Closure ? $property($source, $args, $viewer, $info) : $property;
+        return $property instanceof \Closure ? $property($source, $args, $context, $info) : $property;
     }
 }

--- a/src/Types/EntityType.php
+++ b/src/Types/EntityType.php
@@ -35,13 +35,13 @@ class EntityType extends ObjectType
      */
     protected function createFieldResolver(array $field, string $key): Closure
     {
-        return function ($source, $args, $viewer) use ($key, $field) {
+        return function ($source, $args, $context) use ($key, $field) {
             if (array_key_exists('policy', $field)) {
-                $this->checkPolicy($field, $key, $source, $args, $viewer);
+                $this->checkPolicy($field, $key, $source, $args, $context);
             }
 
             if (array_key_exists('resolve', $field)) {
-                return $field['resolve']($source, $args, $viewer);
+                return $field['resolve']($source, $args, $context);
             } else {
                 if (is_array($source) || $source instanceof \ArrayAccess) {
                     return $source[$key] ?? null;

--- a/tests/Definitions/UserDefinition.php
+++ b/tests/Definitions/UserDefinition.php
@@ -20,11 +20,11 @@ class UserDefinition implements IntrospectableContract
         return [
             'name' => Bakery::string(),
             'email' => Bakery::string()->unique(),
-            'type' => Bakery::string(),
+            'type' => Bakery::string()->canStoreWhen('setType'),
             'password' => Bakery::string()->policy('readPassword'),
             'secret_information' => Bakery::string()
-                ->policy(function (User $user, $args, Authenticatable $viewer = null) {
-                    return $viewer && $user->is($viewer);
+                ->policy(function (Authenticatable $user, User $source) {
+                    return $user && $source->is($user);
                 })->nullable(),
         ];
     }
@@ -33,8 +33,8 @@ class UserDefinition implements IntrospectableContract
     {
         return [
             'articles' => Bakery::collection(ArticleDefinition::class)
-                ->policy(function (User $user, $args, Authenticatable $viewer = null) {
-                    return $viewer && $user->is($viewer);
+                ->policy(function (Authenticatable $user, User $source) {
+                    return $user && $source->is($user);
                 }),
             'customRoles' => Bakery::collection(RoleDefinition::class),
             'phone' => Bakery::model(PhoneDefinition::class),

--- a/tests/Stubs/Policies/UserPolicy.php
+++ b/tests/Stubs/Policies/UserPolicy.php
@@ -47,6 +47,11 @@ class UserPolicy
         return true;
     }
 
+    public function setEmail()
+    {
+        return true;
+    }
+
     public function setType()
     {
         return false;

--- a/tests/Stubs/Policies/UserPolicy.php
+++ b/tests/Stubs/Policies/UserPolicy.php
@@ -47,6 +47,11 @@ class UserPolicy
         return true;
     }
 
+    public function setType()
+    {
+        return false;
+    }
+
     public function readPassword(Authenticatable $viewer, User $user): bool
     {
         return $viewer && $user->is($viewer);

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -16,7 +16,9 @@ class TypeTest extends FeatureTestCase
         $this->actingAs($user);
 
         $type = new Type();
-        $type->canStore(function () { return true; });
+        $type->canStore(function () {
+            return true;
+        });
 
         $this->assertTrue($type->checkStorePolicy($user, 'email'));
     }
@@ -30,7 +32,9 @@ class TypeTest extends FeatureTestCase
         $this->actingAs($user);
 
         $type = new Type();
-        $type->canStore(function () { return false; });
+        $type->canStore(function () {
+            return false;
+        });
 
         $type->checkStorePolicy($user, 'email');
     }

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -59,4 +59,18 @@ class TypeTest extends FeatureTestCase
 
         $this->assertTrue($type->checkStorePolicy($user, 'email'));
     }
+
+    /** @test */
+    public function it_throws_exception_if_policy_does_not_exist()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $user = new User();
+        $this->actingAs($user);
+
+        $type = new Type();
+        $type->canStoreWhen('nonExistingPolicy');
+
+        $this->assertTrue($type->checkStorePolicy($user, 'email'));
+    }
 }

--- a/tests/Types/TypeTest.php
+++ b/tests/Types/TypeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bakery\Tests\Types;
+
+use Bakery\Tests\Models\User;
+use Bakery\Tests\FeatureTestCase;
+use Bakery\Types\Definitions\Type;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class TypeTest extends FeatureTestCase
+{
+    /** @test */
+    public function it_can_set_a_store_policy_with_a_closure()
+    {
+        $user = new User();
+        $this->actingAs($user);
+
+        $type = new Type();
+        $type->canStore(function () { return true; });
+
+        $this->assertTrue($type->checkStorePolicy($user, 'email'));
+    }
+
+    /** @test */
+    public function it_throws_exception_if_policy_returns_false()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $user = new User();
+        $this->actingAs($user);
+
+        $type = new Type();
+        $type->canStore(function () { return false; });
+
+        $type->checkStorePolicy($user, 'email');
+    }
+
+    /** @test */
+    public function it_can_set_a_store_policy_with_a_policy_name_that_returns_true()
+    {
+        $user = new User();
+        $this->actingAs($user);
+        $type = new Type();
+        $type->canStoreWhen('setEmail');
+
+        $this->assertTrue($type->checkStorePolicy($user, 'email'));
+    }
+
+    /** @test */
+    public function it_can_set_a_store_policy_with_a_policy_name_that_returns_false()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $user = new User();
+        $this->actingAs($user);
+
+        $type = new Type();
+        $type->canStoreWhen('setType');
+
+        $this->assertTrue($type->checkStorePolicy($user, 'email'));
+    }
+}


### PR DESCRIPTION
This PR aims to make policies for storing data more clear. It tries to following a Nova-like API to make it easier to use in the Laravel ecosystem.

- [x] Remove magic `set{$field}Attribute` policy.
- [x] No longer use context as a way to store the currently authenticated user, but rather use `auth()->user()` consistent.
- [x] Add `$field->storePolicy($policy)` method.
- [x] Add `$field->canStore(Closure $closure)` method.
- [x] Add `$field->canStoreWhen(string $policy)` method.