### PR TITLE
🔥 Fix selected fields overridden by orderBy selected fields

### DIFF
--- a/src/Traits/OrdersQueries.php
+++ b/src/Traits/OrdersQueries.php
@@ -72,8 +72,11 @@ trait OrdersQueries
      */
     protected function orderBy(Builder $query, string $column, string $ordering)
     {
-        $query->addSelect($column);
+        // Alias so this doesn't conflict with actually selected fields.
+        $alias = 'bakery_' . str_replace('.', '_', $column);
 
-        return $query->orderBy($column, $ordering);
+        $query->addSelect("{$column} as {$alias}");
+
+        return $query->orderBy($alias, $ordering);
     }
 }

--- a/src/Traits/OrdersQueries.php
+++ b/src/Traits/OrdersQueries.php
@@ -73,7 +73,7 @@ trait OrdersQueries
     protected function orderBy(Builder $query, string $column, string $ordering)
     {
         // Alias so this doesn't conflict with actually selected fields.
-        $alias = 'bakery_' . str_replace('.', '_', $column);
+        $alias = 'bakery_'.str_replace('.', '_', $column);
 
         $query->addSelect("{$column} as {$alias}");
 


### PR DESCRIPTION
If the `articles.name` column is selected and we want to order by `category.name`, then we should alias the `category.name` to something else so it doesn't override the `name` column in the result.