### PR TITLE
⚙️ Make the Field Macroable

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -4,9 +4,12 @@ namespace Bakery;
 
 use Bakery\Support\TypeRegistry;
 use Bakery\Fields\PolymorphicField;
+use Illuminate\Support\Traits\Macroable;
 
 class Field
 {
+    use Macroable;
+
     /**
      * Get the current bound registry.
      */


### PR DESCRIPTION
This allows users to add their own shorthands for types such as `Timestamp` and `BigInt`, without having to use `Field::type('TimestampType')`. With macro's they can use them like `Field::timestamp()` and `Field::bigInt()`.