### PR TITLE
Drop support for Laravel <= 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 env:
-  - TESTBENCH_VERSION="3.6.*" # Laravel 5.6
-  - TESTBENCH_VERSION="3.7.*" # Laravel 5.7
   - TESTBENCH_VERSION="3.8.*" # Laravel 5.8
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "illuminate/support": "5.6.*|5.7.*|5.8.*",
+    "illuminate/support": "5.8.*",
     "webonyx/graphql-php": "^0.13.0",
     "ext-json": "*"
   },

--- a/src/Traits/JoinsRelationships.php
+++ b/src/Traits/JoinsRelationships.php
@@ -27,7 +27,7 @@ trait JoinsRelationships
             $foreignPivotKeyName = $relation->getQualifiedForeignPivotKeyName();
             $relatedPivotKeyName = $relation->getQualifiedRelatedPivotKeyName();
             $parentKeyName = $relation->getQualifiedParentKeyName();
-            $relatedKeyName = $relation->getRelatedKeyName();
+            $relatedKeyName = $related->getQualifiedKeyName();
 
             $query->join($relation->getTable(), $parentKeyName, '=', $foreignPivotKeyName, $type, $where);
             $query->join($related->getTable(), $relatedPivotKeyName, '=', $relatedKeyName, $type, $where);

--- a/src/Traits/JoinsRelationships.php
+++ b/src/Traits/JoinsRelationships.php
@@ -19,19 +19,23 @@ trait JoinsRelationships
         $related = $relation->getRelated();
 
         if ($relation instanceof Relations\BelongsTo) {
-            $foreignKeyName = method_exists($relation, 'getQualifiedForeignKey')
-                ? $relation->getQualifiedForeignKey() : $relation->getQualifiedForeignKeyName();
-            $query->join($related->getTable(), $relation->getQualifiedOwnerKeyName(), '=', $foreignKeyName, $type, $where);
-        } elseif ($relation instanceof Relations\BelongsToMany) {
-            $foreignPivotKeyName = method_exists($relation, 'getQualifiedForeignPivotKeyName')
-                ? $relation->getQualifiedForeignPivotKeyName() : $relation->getQualifiedForeignKeyName();
-            $relatedPivotKeyName = method_exists($relation, 'getQualifiedRelatedPivotKeyName')
-                ? $relation->getQualifiedRelatedPivotKeyName() : $relation->getQualifiedRelatedKeyName();
+            $ownerKeyName = $relation->getQualifiedOwnerKeyName();
+            $foreignKeyName = $relation->getQualifiedForeignKeyName();
 
-            $query->join($relation->getTable(), $relation->getQualifiedParentKeyName(), '=', $foreignPivotKeyName, $type, $where);
-            $query->join($related->getTable(), $relatedPivotKeyName, '=', $related->getQualifiedKeyName(), $type, $where);
+            $query->join($related->getTable(), $ownerKeyName, '=', $foreignKeyName, $type, $where);
+        } elseif ($relation instanceof Relations\BelongsToMany) {
+            $foreignPivotKeyName = $relation->getQualifiedForeignPivotKeyName();
+            $relatedPivotKeyName = $relation->getQualifiedRelatedPivotKeyName();
+            $parentKeyName = $relation->getQualifiedParentKeyName();
+            $relatedKeyName = $relation->getRelatedKeyName();
+
+            $query->join($relation->getTable(), $parentKeyName, '=', $foreignPivotKeyName, $type, $where);
+            $query->join($related->getTable(), $relatedPivotKeyName, '=', $relatedKeyName, $type, $where);
         } elseif ($relation instanceof Relations\HasOneOrMany) {
-            $query->join($related->getTable(), $relation->getQualifiedForeignKeyName(), '=', $relation->getQualifiedParentKeyName(), $type, $where);
+            $foreignKeyName = $relation->getQualifiedForeignKeyName();
+            $parentKeyName = $relation->getQualifiedParentKeyName();
+
+            $query->join($related->getTable(), $foreignKeyName, '=', $parentKeyName, $type, $where);
         }
 
         return $query;


### PR DESCRIPTION
In preparation of the upcoming `3.0` release I would like to propose to drop support for older versions of Laravel to improve mainatainability and remove version-dependent code.