### PR TITLE
[4.x] Use ModelSchema typename for queries

### DIFF
--- a/src/Mutations/AttachPivotMutation.php
+++ b/src/Mutations/AttachPivotMutation.php
@@ -27,7 +27,7 @@ class AttachPivotMutation extends EloquentMutation
 
         $relation = Str::studly($this->pivotRelationName);
 
-        return 'attach'.$relation.'On'.$this->modelSchema->typename();
+        return 'attach'.$relation.'On'.$this->modelSchema->getTypename();
     }
 
     /**

--- a/src/Mutations/CreateMutation.php
+++ b/src/Mutations/CreateMutation.php
@@ -3,6 +3,7 @@
 namespace Bakery\Mutations;
 
 use Bakery\Support\Arguments;
+use Bakery\Utils\Utils;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,7 +20,7 @@ class CreateMutation extends EloquentMutation
             return $this->name;
         }
 
-        return 'create'.$this->modelSchema->typename();
+        return 'create'.$this->modelSchema->getTypename();
     }
 
     /**

--- a/src/Mutations/CreateMutation.php
+++ b/src/Mutations/CreateMutation.php
@@ -3,7 +3,6 @@
 namespace Bakery\Mutations;
 
 use Bakery\Support\Arguments;
-use Bakery\Utils\Utils;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Mutations/DeleteMutation.php
+++ b/src/Mutations/DeleteMutation.php
@@ -21,7 +21,7 @@ class DeleteMutation extends EloquentMutation
             return $this->name;
         }
 
-        return 'delete'.$this->modelSchema->typename();
+        return 'delete'.$this->modelSchema->getTypename();
     }
 
     /**

--- a/src/Mutations/DetachPivotMutation.php
+++ b/src/Mutations/DetachPivotMutation.php
@@ -26,7 +26,7 @@ class DetachPivotMutation extends EloquentMutation
 
         $relation = Str::studly($this->pivotRelationName);
 
-        return 'detach'.$relation.'On'.$this->modelSchema->typename();
+        return 'detach'.$relation.'On'.$this->modelSchema->getTypename();
     }
 
     /**

--- a/src/Mutations/UpdateMutation.php
+++ b/src/Mutations/UpdateMutation.php
@@ -20,7 +20,7 @@ class UpdateMutation extends EloquentMutation
             return $this->name;
         }
 
-        return 'update'.$this->modelSchema->typename();
+        return 'update'.$this->modelSchema->getTypename();
     }
 
     /**

--- a/src/Queries/EloquentCollectionQuery.php
+++ b/src/Queries/EloquentCollectionQuery.php
@@ -36,7 +36,7 @@ class EloquentCollectionQuery extends EloquentQuery
             return $this->name;
         }
 
-        return Utils::plural($this->modelSchema->getModel());
+        return Utils::plural($this->modelSchema->getTypename());
     }
 
     /**

--- a/src/Queries/SingleEntityQuery.php
+++ b/src/Queries/SingleEntityQuery.php
@@ -22,7 +22,7 @@ class SingleEntityQuery extends EloquentQuery
             return $this->name;
         }
 
-        return Utils::single($this->model);
+        return Utils::single($this->modelSchema->getTypename());
     }
 
     /**


### PR DESCRIPTION
When using a `ModelSchema` that has a custom typename, it should use that for generating the `SingleEntityQuery` and `EloquentCollectionQuery` names.
